### PR TITLE
Fix mixed-content warnings and some improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
+<!doctype html>
 <html>
-<title>==@= Chess =@==</title>
 <head>
-<style></style>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+<title>==@= Chess =@==</title>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 <script>
-var imgFile = 'http://i.stack.imgur.com/SeZ5y.png';
+var imgFile = 'https://i.stack.imgur.com/SeZ5y.png';
 var colors = ['black','white'];
 var turnColor = 'white';
 var bgNormal = 'rgb(153,102,204)';


### PR DESCRIPTION
Changing to https:// [as broadly recommended](http://www.paulirish.com/2010/the-protocol-relative-url/) will fix mixed content warnings.

Adding `<!doctype html>` will make page render in standards mode. Also removed a empty `<style>` and put `<head>` before `<title>`.